### PR TITLE
Member list should always take full height

### DIFF
--- a/main.css
+++ b/main.css
@@ -1203,6 +1203,9 @@ svg.slider-TkfMQL svg, .bd-switch-slider>svg {
 .layout-2DM8Md {
   border-radius: var(--border-radius-2);
 }
+.membersWrap-2h-GB4 {
+  min-height: 100%;
+}
 .members-1998pB, .members-1998pB>div, .tabs-3L9Rgq, .container-1CU5bi {
   background-color: var(--background-tertiary);
 }


### PR DESCRIPTION
Without this, the member list background wouldn't reach the bottom if there weren't enough members to require full height, meaning you'd see the darker background colour below it

Before/After
![image](https://user-images.githubusercontent.com/36897817/141113212-e98fe148-2704-429e-a319-2e4324bd340e.png)

![image](https://user-images.githubusercontent.com/36897817/141113412-1066d51d-6c68-4ca6-8166-71fce5ce6a78.png)