### PR TITLE
Implement styles for server home page and forum/forum threads

### DIFF
--- a/main.css
+++ b/main.css
@@ -1913,3 +1913,7 @@ body:not(.powercord) .panels-3wFtMD::after {
 .bf-toolbar .format:active {
   background: var(--background-modifier-active) !important;
 }
+/* Server "home page" beta bg */
+.homeContainer-r4Hvv1 {
+  background-color: var(--background-2);
+}

--- a/main.css
+++ b/main.css
@@ -1924,7 +1924,7 @@ body:not(.powercord) .panels-3wFtMD::after {
   border-radius: var(--border-radius-1);
 }
 
-/* Annoying line above forum thread */
-.chat-25x62K:before {
+/* Annoying line above forum thread, home page channel popout */
+.chat-25x62K::before, .chat-3t9F_n::before {
   content: unset;
 }

--- a/main.css
+++ b/main.css
@@ -1913,11 +1913,18 @@ body:not(.powercord) .panels-3wFtMD::after {
 .bf-toolbar .format:active {
   background: var(--background-modifier-active) !important;
 }
-/* Server "home page" beta bg */
-.homeContainer-r4Hvv1 {
+
+/* Server "home page", forum bg */
+.homeContainer-r4Hvv1, [data-list-id*="forum-channel-list-"] {
   background-color: var(--background-2);
 }
-/* Server forum bg */
-[data-list-id*="forum-channel-list-"] {
-	background-color: var(--background-2);
+
+.chatContent-3KubbW[aria-label*="(thread)"] {
+  background-color: var(--background-1);
+  border-radius: var(--border-radius-1);
+}
+
+/* Annoying line above forum thread */
+.chat-25x62K:before {
+  content: unset;
 }

--- a/main.css
+++ b/main.css
@@ -1917,3 +1917,7 @@ body:not(.powercord) .panels-3wFtMD::after {
 .homeContainer-r4Hvv1 {
   background-color: var(--background-2);
 }
+/* Server forum bg */
+[data-list-id*="forum-channel-list-"] {
+	background-color: var(--background-2);
+}

--- a/main.css
+++ b/main.css
@@ -17,7 +17,7 @@
   --text-brand: var(--brand-experiment);
 }
 .tabBody-2dgbAs, .chat-2ZfjoI, .container-1NXEtd, .container-1oAagU, .privateChannels-oVe7HL, .homeWrapperNormal-bu1BS6 {
-  background-color: var(--background-tertiary);
+  background-color: var(--background-tertiary) !important;
 }
 .peopleColumn-1wMU14, .chatContent-3KubbW:not(.container-3XgAHv *), .pageWrapper-2PwDoS, .scroller-29cQFV, .stageSection-3mAD8V {
   border-radius: var(--border-radius-1);


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/50891500/180721069-e66c45f9-3bbb-444c-8c16-71f2e3605439.png)
After: 
![image](https://user-images.githubusercontent.com/50891500/180722077-5b4195e6-aa10-42ad-ab6a-b79b0c374186.png)


\* The weird bar on the right side is caused by a 10px margin on the `.pageWrapper-2PwDoS, .content-1jQy2l, .applicationStore-2nk7Lo` classes ([here](https://github.com/schnensch0/zelk/blob/main/main.css#L40)). I'm not entirely sure what the purpose of this is, but I didn't want to mess with it, as I don't know where else the `.content-1jQy2l` class appears.